### PR TITLE
Updating to enable java 8 to be installed via bootstrap

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -25,6 +25,7 @@ echo "Installing OpenJDK"
 echo "--------------------------------------------------------------------------"
 echo " "
 
+apt-get install software-properties-common
 add-apt-repository -y ppa:openjdk-r/ppa
 apt-get update
 apt-get -y install vim curl openjdk-8-jdk 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -25,7 +25,7 @@ echo "Installing OpenJDK"
 echo "--------------------------------------------------------------------------"
 echo " "
 
-apt-get install software-properties-common
+apt-get -y install software-properties-common
 add-apt-repository -y ppa:openjdk-r/ppa
 apt-get update
 apt-get -y install vim curl openjdk-8-jdk 


### PR DESCRIPTION
apt-add-repository tool is missing so java 8 installation fails.  This corrects that in the bootstrap file.